### PR TITLE
Fix functional tests after pytest-helpers-namespace drop

### DIFF
--- a/molecule_lxd/test/conftest.py
+++ b/molecule_lxd/test/conftest.py
@@ -19,5 +19,10 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
+import pytest
 
-from molecule.test.conftest import *  # noqa
+
+@pytest.fixture
+def driver_name() -> str:
+    """Return name of the driver to be tested."""
+    return "lxd"

--- a/molecule_lxd/test/test_func.py
+++ b/molecule_lxd/test/test_func.py
@@ -19,37 +19,39 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 """Functional tests"""
-import pytest
-import os
+import pathlib
 
-from molecule import logger, util
 from molecule.util import run_command
 from molecule.test.conftest import change_dir_to
 
-LOG = logger.get_logger(__name__)
 
+def test_command_init_scenario(tmp_path: pathlib.Path):
+    """Verify that init scenario works."""
+    scenario_name = "default"
 
-def test_command_init_scenario(temp_dir):
-    role_directory = os.path.join(temp_dir.strpath, "test-init")
-    cmd = ["molecule", "init", "role", "test-init"]
-    result = run_command(cmd)
-    assert result.returncode == 0
-
-    with change_dir_to(role_directory):
-        molecule_directory = pytest.helpers.molecule_directory()
-        scenario_directory = os.path.join(molecule_directory, "test-scenario")
-        options = {"role_name": "test-init", "driver-name": "lxd"}
+    with change_dir_to(tmp_path):
+        scenario_directory = tmp_path / "molecule" / scenario_name
         cmd = [
             "molecule",
             "init",
             "scenario",
-            "test-scenario",
-            *util.dict2args(options),
+            scenario_name,
+            "--driver-name",
+            "lxd",
         ]
         result = run_command(cmd)
         assert result.returncode == 0
-        assert os.path.isdir(scenario_directory)
 
-        cmd = ["molecule", "--debug", "test", "-s", "test-scenario"]
+        assert scenario_directory.exists()
+
+        # run molecule reset as this may clean some leftovers from other
+        # test runs and also ensure that reset works.
+        result = run_command(["molecule", "reset"])  # default scenario
+        assert result.returncode == 0
+
+        result = run_command(["molecule", "reset", "-s", scenario_name])
+        assert result.returncode == 0
+
+        cmd = ["molecule", "--debug", "test", "-s", scenario_name]
         result = run_command(cmd)
         assert result.returncode == 0

--- a/tox.ini
+++ b/tox.ini
@@ -52,8 +52,8 @@ passenv =
     USER
 deps =
     ansible >= 2.9
-    py{36,37,38,39}: molecule[test]
-    py{36,37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@master#egg=molecule[test]
+    py{36,37,38,39}-{!devel}: molecule[test]>=3.4.0
+    py{36,37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@main#egg=molecule[test]
 allowlist_externals =
     bash
     twine


### PR DESCRIPTION
- Fix tests due to the ansible-community/molecule#3195
- Install correct molecule versions for tests