### PR TITLE
Update driver to match latest requirements

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -28,7 +28,9 @@ jobs:
             PREFIX: PYTEST_REQPASS=2
           - tox_env: py39
             PREFIX: PYTEST_REQPASS=2
-          - tox_env: py39-devel
+          - tox_env: py310
+            PREFIX: PYTEST_REQPASS=2
+          - tox_env: py310-devel
             PREFIX: PYTEST_REQPASS=2
           - tox_env: packaging
 

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -48,6 +48,18 @@ jobs:
           v = '${{ matrix.tox_env }}'.split('-')[0].lstrip('py')
           print('::set-output name=version::{0}.{1}'.format(v[0],v[1:]))
 
+      - name: Enable caching of ~/.cache/pip
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ steps.py_ver.outputs.version }}-${{ hashFiles('**/setup.cfg', 'tox.ini') }}
+
+      - name: Enable caching of ~/.cache/pre-commit
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ steps.py_ver.outputs.version }}-${{ hashFiles('.pre-commit-config.yaml') }}
+
       # Even our lint and other envs need access to tox
       - name: Install a default Python
         uses: actions/setup-python@v2

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: 1 0 * * *  # Run daily at 0:01 UTC
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: ${{ matrix.tox_env }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    molecule >= 3.2.0
+    molecule >= 3.4.0
     pyyaml >= 5.1, < 6
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
     Topic :: System :: Systems Administration
     Topic :: Utilities

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[aliases]
-dists = clean --all sdist bdist_wheel
-
 [metadata]
 name = molecule-lxd
 url = https://github.com/ansible-community/molecule-lxd
@@ -53,11 +50,6 @@ package_dir =
   = src
 include_package_data = True
 zip_safe = False
-
-# These are required during `setup.py` run:
-setup_requires =
-    setuptools_scm >= 1.15.0
-    setuptools_scm_git_archive >= 1.0
 
 # These are required in actual runtime:
 install_requires =

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-# !/usr/bin/env python
-import setuptools
-
-
-if __name__ == "__main__":
-    setuptools.setup(use_scm_version=True, setup_requires=["setuptools_scm"])

--- a/src/molecule_lxd/driver.py
+++ b/src/molecule_lxd/driver.py
@@ -66,6 +66,8 @@ class LXD(Driver):
               - default
             force_stop: True|False
             ignore_volatile_options: false
+            target: node_name
+            type: virtual-machine
 
     Provide a list of files Molecule will preserve, relative to the scenario
     ephemeral directory, after any ``destroy`` subcommand execution.

--- a/src/molecule_lxd/driver.py
+++ b/src/molecule_lxd/driver.py
@@ -18,6 +18,7 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 import os
+from typing import Dict
 from molecule import logger
 from molecule.api import Driver
 
@@ -120,3 +121,8 @@ class LXD(Driver):
 
     def modules_dir(self):
         return os.path.join(os.path.dirname(__file__), "modules")
+
+    @property
+    def required_collections(self) -> Dict[str, str]:
+        """Return collections dict containing names and versions required."""
+        return {"community.general": "4.1.0"}

--- a/src/molecule_lxd/driver.py
+++ b/src/molecule_lxd/driver.py
@@ -65,6 +65,7 @@ class LXD(Driver):
             profiles:
               - default
             force_stop: True|False
+            ignore_volatile_options: false
 
     Provide a list of files Molecule will preserve, relative to the scenario
     ephemeral directory, after any ``destroy`` subcommand execution.

--- a/src/molecule_lxd/playbooks/create.yml
+++ b/src/molecule_lxd/playbooks/create.yml
@@ -17,7 +17,7 @@
 
   tasks:
     - name: Create molecule instance(s)
-      lxd_container:
+      community.general.lxd_container:
         name: "{{ item.name }}"
         state: started
         source: "{{ default_source | combine(item.source | default({})) }}"

--- a/src/molecule_lxd/playbooks/create.yml
+++ b/src/molecule_lxd/playbooks/create.yml
@@ -24,6 +24,7 @@
         config: "{{ default_config | combine(item.config | default({})) }}"
         architecture: "{{ item.architecture | default(omit) }}"
         devices: "{{ item.devices | default(omit) }}"
+        ignore_volatile_options: "{{ item.ignore_volatile_options | default(false) }}"
         profiles: "{{ item.profiles | default(omit) }}"
         url: "{{ item.url | default(omit) }}"
         cert_file: "{{ item.cert_file | default(omit) }}"

--- a/src/molecule_lxd/playbooks/create.yml
+++ b/src/molecule_lxd/playbooks/create.yml
@@ -25,6 +25,8 @@
         architecture: "{{ item.architecture | default(omit) }}"
         devices: "{{ item.devices | default(omit) }}"
         ignore_volatile_options: "{{ item.ignore_volatile_options | default(false) }}"
+        target: "{{ item.target | default(omit) }}"
+        type: "{{ item.type | default(omit) }}"
         profiles: "{{ item.profiles | default(omit) }}"
         url: "{{ item.url | default(omit) }}"
         cert_file: "{{ item.cert_file | default(omit) }}"

--- a/src/molecule_lxd/playbooks/destroy.yml
+++ b/src/molecule_lxd/playbooks/destroy.yml
@@ -15,6 +15,7 @@
         cert_file: "{{ item.cert_file | default(omit) }}"
         key_file: "{{ item.key_file | default(omit) }}"
         trust_password: "{{ item.trust_password | default(omit) }}"
+        ignore_volatile_options: "{{ item.ignore_volatile_options | default(false) }}"
       loop: "{{ molecule_yml.platforms }}"
       loop_control:
         label: "{{ item.name }}"

--- a/src/molecule_lxd/playbooks/destroy.yml
+++ b/src/molecule_lxd/playbooks/destroy.yml
@@ -7,7 +7,7 @@
 
   tasks:
     - name: Destroy molecule instance(s)
-      lxd_container:
+      community.general.lxd_container:
         name: "{{ item.name }}"
         state: absent
         force_stop: "{{ item.force_stop | default(true) }}"

--- a/src/molecule_lxd/playbooks/prepare.yml
+++ b/src/molecule_lxd/playbooks/prepare.yml
@@ -7,7 +7,7 @@
   tasks:
     - name: Install basic packages to bare containers
       tags: skip_ansible_lint
-      raw: |
+      ansible.builtin.raw: |
         if [ -x "$(command -v apt-get)" ]; then
           export DEBIAN_FRONTEND=noninteractive
           apt-get update --quiet && apt-get install --assume-yes --no-install-recommends ca-certificates curl python3 python3-apt

--- a/src/molecule_lxd/playbooks/prepare.yml
+++ b/src/molecule_lxd/playbooks/prepare.yml
@@ -23,3 +23,7 @@
         elif [ -x "$(command -v pacman)" ]; then
           pacman -Syu --noconfirm ca-certificates curl python3
         fi
+      register: _prepare
+      until: not _prepare.failed
+      retries: 3
+      delay: 10

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ minversion = 3.18.0
 envlist =
     lint
     packaging
-    py{36,37,38,39}
-    py{36,37,38,39}-{devel}
+    py{36,37,38,39,310}
+    py{36,37,38,39,310}-{devel}
 
 # do not enable skip missing to avoid CI false positives
 skip_missing_interpreters = False
@@ -52,8 +52,8 @@ passenv =
     USER
 deps =
     ansible >= 2.9
-    py{36,37,38,39}-{!devel}: molecule[test]>=3.4.0
-    py{36,37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@main#egg=molecule[test]
+    py{36,37,38,39,310}-{!devel}: molecule[test]>=3.4.0
+    py{36,37,38,39,310}-{devel}: git+https://github.com/ansible-community/molecule.git@main#egg=molecule[test]
 allowlist_externals =
     bash
     twine

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,13 @@ usedevelop = True
 download = true
 extras = test
 commands =
-    pytest --collect-only
-    pytest --color=yes {tty:-s}
+    # failsafe as pip may install incompatible dependencies
+    pip check
+    # failsafe for broken installation
+    molecule --version
+    # failsafe for preventing changes that may break pytest collection
+    python -m pytest -p no:cov --collect-only
+    python -m pytest {posargs:-l}
 setenv =
     ANSIBLE_FORCE_COLOR={env:ANSIBLE_FORCE_COLOR:1}
     ANSIBLE_INVENTORY={toxinidir}/tests/hosts.ini

--- a/tox.ini
+++ b/tox.ini
@@ -80,18 +80,13 @@ usedevelop = false
 # don't install molecule itself in this env
 skip_install = true
 deps =
-    collective.checkdocs >= 0.2
-    pep517 >= 0.8.2
-    pip >= 20.2.2
-    toml >= 0.10.1
+    build >= 0.7.0
     twine >= 3.2.0  # pyup: ignore
 setenv =
 commands =
     rm -rfv {toxinidir}/dist/
-    python -m pep517.build \
-      --source \
-      --binary \
-      --out-dir {toxinidir}/dist/ \
+    python -m build \
+      --outdir {toxinidir}/dist/ \
       {toxinidir}
     # metadata validation
-    sh -c "python -m twine check {toxinidir}/dist/*"
+    sh -c "python -m twine check --strict {toxinidir}/dist/*"


### PR DESCRIPTION
- Expose required collection
- Use correct PEP 517 build frontend
- Remove setup.py file
- Added support for python 3.10
- Extend testenv commands
- Use FQCN tasks in playbooks
- Fix lxd_container deprecation warning
- Update playbooks
  - Added new control properties: `target` and `type`
  - Added retries to `prepare.yml` playbook
- Enable workflow cache
- Cancel concurrent workflows