### PR TITLE
Extend pre-commit hooks

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - main
-      - 'releases/**'
-      - 'stable/**'
+      - "releases/**"
+      - "stable/**"
 
 jobs:
   push:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: 1 0 * * *  # Run daily at 0:01 UTC
+    - cron: 1 0 * * * # Run daily at 0:01 UTC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,12 +18,18 @@ repos:
         # https://github.com/pre-commit/pre-commit-hooks/issues/273
         args: ["--unsafe"]
   - repo: https://github.com/pre-commit/mirrors-prettier
+    # keep it before yamllint
     rev: v2.6.2
     hooks:
       - id: prettier
         additional_dependencies:
           - prettier
           - prettier-plugin-toml
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.26.3
+    hooks:
+      - id: yamllint
+        args: ["--strict"]
   - repo: https://github.com/PyCQA/doc8.git
     rev: 0.11.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,13 @@ repos:
         exclude: "cookiecutter.*"
         # https://github.com/pre-commit/pre-commit-hooks/issues/273
         args: ["--unsafe"]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.6.2
+    hooks:
+      - id: prettier
+        additional_dependencies:
+          - prettier
+          - prettier-plugin-toml
   - repo: https://github.com/PyCQA/doc8.git
     rev: 0.11.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 default_language_version:
   python: python3
-minimum_pre_commit_version: "1.14.0"
+minimum_pre_commit_version: "2.15.0"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: mixed-line-ending
-      - id: check-byte-order-marker
+      - id: fix-byte-order-marker
       - id: check-merge-conflict
       - id: debug-statements
       - id: check-yaml

--- a/.yamllint
+++ b/.yamllint
@@ -7,5 +7,21 @@ rules:
   brackets:
     max-spaces-inside: 1
     level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
   document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
   line-length: disable
+  truthy: disable

--- a/src/molecule_lxd/cookiecutter/cookiecutter.json
+++ b/src/molecule_lxd/cookiecutter/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "molecule_directory": "molecule",
-    "role_name": "OVERRIDDEN",
-    "scenario_name": "OVERRIDDEN"
+  "molecule_directory": "molecule",
+  "role_name": "OVERRIDDEN",
+  "scenario_name": "OVERRIDDEN"
 }


### PR DESCRIPTION
- enable prettier hook
- enable yamllint hook
- replace deprecated hook `check-byte-order-marker` by `fix-byte-order-marker`
- bump `minimum_pre_commit_version`