### PR TITLE
use wait_for_ipv4_addresses var

### DIFF
--- a/src/molecule_lxd/playbooks/create.yml
+++ b/src/molecule_lxd/playbooks/create.yml
@@ -32,7 +32,7 @@
         cert_file: "{{ item.cert_file | default(omit) }}"
         key_file: "{{ item.key_file | default(omit) }}"
         trust_password: "{{ item.trust_password | default(omit) }}"
-        wait_for_ipv4_addresses: true
+        wait_for_ipv4_addresses: "{{ item.wait_for_ipv4_addresses | default(true) }}"
         timeout: 600
       loop: "{{ molecule_yml.platforms }}"
       loop_control:


### PR DESCRIPTION
wait_for_ipv4_addresses should be configurable upon create. we use a 2nd network interface without fixed address to test ansible roles, which waits 600s and times out if wait_for_ipv4_addresses is set to true